### PR TITLE
Add `exec` permissions for installed jq

### DIFF
--- a/scripts/unixish.sh
+++ b/scripts/unixish.sh
@@ -107,6 +107,8 @@ echo "Src: $RUNNER_TEMP/${_bin_name}"
 echo "Dst: $RUNNER_TOOL_CACHE/jq/jq"
 mv "$RUNNER_TEMP/${_bin_name}" "$RUNNER_TOOL_CACHE/jq/jq"
 
+chmod +x "$RUNNER_TOOL_CACHE/jq/jq"
+
 echo "Adding $RUNNER_TOOL_CACHE/jq to path..."
 echo "$RUNNER_TOOL_CACHE/jq" >> $GITHUB_PATH
 


### PR DESCRIPTION
Without chmod fix 
https://github.com/cloudposse/github-action-preview-environment-controller/actions/runs/3380627873/jobs/5613620346

With chmod fix 
https://github.com/cloudposse/github-action-preview-environment-controller/actions/runs/3380665448/jobs/5613698678

Your tests does not check the version 
