### PR TITLE
use curl instead of wget to avoid download failure on macOS

### DIFF
--- a/scripts/unixish-17.sh
+++ b/scripts/unixish-17.sh
@@ -73,7 +73,7 @@ echo '::group::Downloading jq'
 echo "Src: ${_dl_url}"
 echo "Dst: ${_dl_path}"
 
-wget -O- "${_dl_url}" > "${_dl_path}"
+curl -L "${_dl_url}" -o "${_dl_path}"
 
 echo '::endgroup::'
 

--- a/scripts/unixish.sh
+++ b/scripts/unixish.sh
@@ -93,7 +93,7 @@ echo '::group::Downloading jq'
 echo "Src: ${_dl_url}"
 echo "Dst: ${_dl_path}"
 
-wget -O- "${_dl_url}" > "${_dl_path}"
+curl -L "${_dl_url}" -o "${_dl_path}"
 
 echo '::endgroup::'
 


### PR DESCRIPTION
Fixes https://github.com/dcarbone/install-jq-action/issues/5