### PR TITLE
Support running action inside containers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -169,3 +169,150 @@ jobs:
           {
               exit 1
           }
+  test-container:
+    strategy:
+      matrix:
+        image:
+          - "ubuntu-22.04"
+          - "ubuntu-20.04"
+        force:
+          - 'true'
+          - 'false'
+        version:
+          - '1.5'
+          - '1.6'
+          - '1.7'
+    name: "Test Action (Container) - (img: ${{ matrix.image }}; version: ${{ matrix.version }}; force: ${{ matrix.force }})"
+    runs-on: ${{ matrix.image }}
+    container:
+      image: node:18.12.1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup jq
+        id: install-jq
+        uses: ./
+        with:
+          version: '${{ matrix.version }}'
+          force: '${{ matrix.force }}'
+
+      - name: Check jq - Unix-ish
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.force == 'true'
+        # language=sh
+        run: |
+          _err=
+          _which="$(which jq)"
+          _vers="$(jq --version)"
+          if [[ "${_which}" != "$RUNNER_TOOL_CACHE/jq/jq" ]]; then
+            echo "jq found at unexpected path."
+            echo "  Expected:   \"$RUNNER_TOOL_CACHE/jq/jq\""
+            echo "  Actual:     \"${_which}\""
+            _err=1
+          fi
+          if [[ "${_vers}" != 'jq-${{ matrix.version }}' ]]; then
+            echo "jq --version returned unexpected value"
+            echo '  Expected:   "jq-${{ matrix.version }}"'
+            echo "  Actual:     \"${_vers}\""
+            _err=1
+          fi
+          if [ -n "${_err}" ]; then exit 1; fi;
+
+      - name: Check Outputs - Unix-ish
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        # language=sh
+        run: |
+          _installed='${{ steps.install-jq.outputs.installed }}'
+          _err=
+          if [[ '${{ matrix.force }}' == 'true' ]]; then
+            # enabling "force" must result in an install
+            if [[ '${{ steps.install-jq.outputs.installed }}' != 'true' ]]; then
+              echo 'Unexpected value for "installed":'
+              echo 'Expected:   "true"'
+              echo 'Actual:     "${{ steps.install-jq.outputs.installed }}"'
+              _err=1
+            fi
+          else
+            if [[ '${{ steps.install-jq.outputs.found }}' == 'true' ]]; then
+              # if found, must not be installed without force
+              if [[ '${{ steps.install-jq.outputs.installed }}' != 'false' ]]; then
+                echo 'Unexpected value for "installed":'
+                echo 'Expected:   "false"'
+                echo 'Actual:     "${{ steps.install-jq.outputs.installed }}"'
+                _err=1
+              fi
+            else
+              # if not found, must be installed
+              if [[ '${{ steps.install-jq.outputs.installed }}' != 'true' ]]; then
+                echo 'Unexpected value for "installed":'
+                echo 'Expected:   "true"'
+                echo 'Actual:     "${{ steps.install-jq.outputs.installed }}"'
+                _err=1
+              fi
+            fi
+          fi
+          if [ -n "${_err}" ]; then exit 1; fi;
+          
+
+      - name: Check jq - Windows-ish
+        if: runner.os == 'Windows' && matrix.force == 'true'
+        # language=powershell
+        run: |
+          Get-Command "jq.exe"
+          $_cmd={jq.exe --version }
+          $_vers=jq.exe --version 2>&1
+          if ( "${_vers}" -ne "jq-${{ matrix.version }}" -and "${_vers}" -ne "jq-${{ matrix.version }}-dirty" )
+          {
+              Write-Host "jq.exe --version returned unexpected value"
+              Write-Host "  Expected:   jq-${{ matrix.version }}"
+              Write-Host "  Actual:     ${_vers}"
+              exit 1
+          }
+
+      - name: Check Outputs - Windows-ish
+        if: runner.os == 'Windows'
+        shell: powershell
+        # language=powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+          $_installed='${{ steps.install-jq.outputs.installed }}'
+          $_err = 0
+          if ("${{ matrix.force }}" -eq "true")
+          {
+              # enabling "force" must result in an install
+              if ("${{ steps.install-jq.outputs.installed }}" -ne "true")
+              {
+                  Write-Host "Unexpected value for installed"
+                  Write-Host "Expected:   true"
+                  Write-Host "Actual:     ${{ steps.install-jq.outputs.installed }}"
+                  $_err=1
+              }
+          }
+          else
+          {
+              if ("${{ steps.install-jq.outputs.found }}" -eq "true")
+              {
+                  # if found, must not be installed without force
+                  if ("${{ steps.install-jq.outputs.installed }}" -ne "false")
+                  {
+                      Write-Host "Unexpected value for installed"
+                      Write-Host "Expected:  false"
+                      Write-Host "Actual:    ${{ steps.install-jq.outputs.installed }}"
+                      $_err=1
+                  }
+              }
+              else
+              {
+                  # if not found, must be installed
+                  if ("${{ steps.install-jq.outputs.installed }}" -ne "true") {
+                      Write-Host "Unexpected value for installed"
+                      Write-Host "Expected:  true"
+                      Write-Host "Actual:    ${{ steps.install-jq.outputs.installed }}"
+                      $_err=1
+                  }
+              }
+          }
+          if ("${_err}" -ne 0)
+          {
+              exit 1
+          }

--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,7 @@ runs:
       env:
         JQ_VERSION: '${{ inputs.version }}'
       # language=sh
-      run: ${{ github.action_path }}/scripts/unixish.sh
+      run: ${GITHUB_ACTION_PATH}/scripts/unixish.sh
 
     - name: 'Install jq - Unix-ish 1.7'
       if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.version == '1.7' && (steps.jq-check-unix.outputs.found == 'false' || inputs.force == 'true')
@@ -54,7 +54,7 @@ runs:
       env:
         JQ_VERSION: '${{ inputs.version }}'
       # language=sh
-      run: ${{ github.action_path }}/scripts/unixish-17.sh
+      run: ${GITHUB_ACTION_PATH}/scripts/unixish-17.sh
 
     - name: 'Check for jq - Windows-ish'
       id: jq-check-windows


### PR DESCRIPTION
Fixes #9 

- Adds test cases for running inside of a container
- Swaps `${{ github.action_path }}` to `${GITHUB_ACTION_PATH}` to fix container compatibility, per https://github.com/actions/runner/issues/2185#issuecomment-1683545859

Windows cases are unchanged since `container:` options are only supported for linux runners, and I don't know powershell syntax. 

### Testing
- [x] Confirmed tests fail without this fix: https://github.com/TaxBusby/install-jq-action/actions/runs/6787803487
- [x] All tests pass with fix: https://github.com/TaxBusby/install-jq-action/actions/runs/6787778940
