### PR TITLE
fix(security): verify download integrity and harden install scripts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -252,7 +252,7 @@ jobs:
     name: "Test Action (Container) - (img: ${{ matrix.image }}; version: ${{ matrix.version }}; force: ${{ matrix.force }})"
     runs-on: '${{ matrix.image }}'
     container:
-      image: node:20
+      image: node:24
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,6 @@ jobs:
         image:
           - "ubuntu-22.04"
           - "ubuntu-24.04"
-          - "macos-13"
           - "macos-14"
           - "macos-15"
           - "macos-26"

--- a/scripts/unixish-17.sh
+++ b/scripts/unixish-17.sh
@@ -13,6 +13,21 @@ case "$JQ_VERSION" in
     ;;
 esac
 
+# Portable SHA256 digest: prefer sha256sum (Linux), fall back to shasum
+# (macOS, ships with the OS via Perl), then openssl. Prints only the hex
+# digest and returns non-zero if no tool is available.
+_compute_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$1" | awk '{print $NF}'
+  else
+    return 1
+  fi
+}
+
 _base_url='https://github.com/jqlang/jq/releases/download'
 
 _arch_env="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
@@ -95,7 +110,10 @@ if curl -fsSL --retry 3 "${_sha_url}" -o "${_sha_path}"; then
     echo "Could not find checksum for \"${_bin_name}\" in ${_sha_url}"
     exit 1
   fi
-  _actual="$(sha256sum "${_dl_path}" | awk '{print $1}')"
+  _actual="$(_compute_sha256 "${_dl_path}")" || {
+    echo "No SHA256 tool available (sha256sum, shasum, openssl)."
+    exit 1
+  }
   if [ "${_expected}" != "${_actual}" ]; then
     echo "Checksum verification failed for \"${_bin_name}\""
     echo "Expected: ${_expected}"

--- a/scripts/unixish-17.sh
+++ b/scripts/unixish-17.sh
@@ -102,7 +102,8 @@ echo '::group::Verifying checksum'
 _sha_url="${_base_url}/jq-$JQ_VERSION/sha256sum.txt"
 _sha_path="$RUNNER_TEMP/jq-$JQ_VERSION.sha256sum.txt"
 
-if curl -fsSL --retry 3 "${_sha_url}" -o "${_sha_path}"; then
+_sha_http_code="$(curl -sSL -o "${_sha_path}" -w '%{http_code}' --retry 3 "${_sha_url}" || true)"
+if [ "${_sha_http_code}" = '200' ]; then
   _expected="$(grep -E " ${_bin_name}\$" "${_sha_path}" | head -n1 | awk '{print $1}' || true)"
   if [ -z "${_expected}" ]; then
     echo "Could not find checksum for \"${_bin_name}\" in ${_sha_url}"
@@ -119,8 +120,11 @@ if curl -fsSL --retry 3 "${_sha_url}" -o "${_sha_path}"; then
     exit 1
   fi
   echo "Checksum verified for \"${_bin_name}\""
-else
+elif [ "${_sha_http_code}" = '404' ]; then
   echo "WARNING: No sha256sum.txt found at ${_sha_url}; skipping checksum verification."
+else
+  echo "Failed to download sha256sum.txt from ${_sha_url} (HTTP ${_sha_http_code})"
+  exit 1
 fi
 
 echo '::endgroup::'

--- a/scripts/unixish-17.sh
+++ b/scripts/unixish-17.sh
@@ -6,6 +6,13 @@ echo '::group::Prep'
 
 # validate input and prepare some vars
 
+case "$JQ_VERSION" in
+  ''|*[!0-9.]*)
+    echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.7.1\"."
+    exit 1
+    ;;
+esac
+
 _base_url='https://github.com/jqlang/jq/releases/download'
 
 _arch_env="$(echo "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')"
@@ -73,7 +80,32 @@ echo '::group::Downloading jq'
 echo "Src: ${_dl_url}"
 echo "Dst: ${_dl_path}"
 
-curl -L "${_dl_url}" -o "${_dl_path}"
+curl -fsSL --retry 3 "${_dl_url}" -o "${_dl_path}"
+
+echo '::endgroup::'
+
+echo '::group::Verifying checksum'
+
+_sha_url="${_base_url}/jq-$JQ_VERSION/sha256sum.txt"
+_sha_path="$RUNNER_TEMP/jq-$JQ_VERSION.sha256sum.txt"
+
+if curl -fsSL --retry 3 "${_sha_url}" -o "${_sha_path}"; then
+  _expected="$(grep -E " ${_bin_name}\$" "${_sha_path}" | head -n1 | awk '{print $1}' || true)"
+  if [ -z "${_expected}" ]; then
+    echo "Could not find checksum for \"${_bin_name}\" in ${_sha_url}"
+    exit 1
+  fi
+  _actual="$(sha256sum "${_dl_path}" | awk '{print $1}')"
+  if [ "${_expected}" != "${_actual}" ]; then
+    echo "Checksum verification failed for \"${_bin_name}\""
+    echo "Expected: ${_expected}"
+    echo "Actual:   ${_actual}"
+    exit 1
+  fi
+  echo "Checksum verified for \"${_bin_name}\""
+else
+  echo "WARNING: No sha256sum.txt found at ${_sha_url}; skipping checksum verification."
+fi
 
 echo '::endgroup::'
 

--- a/scripts/unixish-17.sh
+++ b/scripts/unixish-17.sh
@@ -6,12 +6,10 @@ echo '::group::Prep'
 
 # validate input and prepare some vars
 
-case "$JQ_VERSION" in
-  ''|*[!0-9.]*)
-    echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.7.1\"."
-    exit 1
-    ;;
-esac
+if ! printf '%s' "$JQ_VERSION" | grep -Eq '^[0-9]+\.[0-9]+(\.[0-9]+)*$'; then
+  echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.7.1\"."
+  exit 1
+fi
 
 # Portable SHA256 digest: prefer sha256sum (Linux), fall back to shasum
 # (macOS, ships with the OS via Perl), then openssl. Prints only the hex

--- a/scripts/unixish.sh
+++ b/scripts/unixish.sh
@@ -6,6 +6,13 @@ echo '::group::Prep'
 
 # validate input and prepare some vars
 
+case "$JQ_VERSION" in
+  ''|*[!0-9.]*)
+    echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.6\"."
+    exit 1
+    ;;
+esac
+
 _base_url='https://github.com/stedolan/jq/releases/download'
 
 _os=
@@ -93,7 +100,7 @@ echo '::group::Downloading jq'
 echo "Src: ${_dl_url}"
 echo "Dst: ${_dl_path}"
 
-curl -L "${_dl_url}" -o "${_dl_path}"
+curl -fsSL --retry 3 "${_dl_url}" -o "${_dl_path}"
 
 echo '::endgroup::'
 

--- a/scripts/unixish.sh
+++ b/scripts/unixish.sh
@@ -6,12 +6,10 @@ echo '::group::Prep'
 
 # validate input and prepare some vars
 
-case "$JQ_VERSION" in
-  ''|*[!0-9.]*)
-    echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.6\"."
-    exit 1
-    ;;
-esac
+if ! printf '%s' "$JQ_VERSION" | grep -Eq '^[0-9]+\.[0-9]+(\.[0-9]+)*$'; then
+  echo "Invalid JQ_VERSION: \"$JQ_VERSION\". Expected a version string like \"1.6\"."
+  exit 1
+fi
 
 _base_url='https://github.com/stedolan/jq/releases/download'
 

--- a/scripts/windowsish-17.ps1
+++ b/scripts/windowsish-17.ps1
@@ -71,6 +71,12 @@ try {
     Invoke-WebRequest -Uri "${_sha_url}" -OutFile "${_sha_path}"
 } catch {
     $_sha_ok = $false
+    if ($_.Exception.Response -and ([int]$_.Exception.Response.StatusCode -eq 404)) {
+        $_sha_ok = $false
+    } else {
+        Write-Host "Failed to download sha256sum.txt from ${_sha_url}"
+        throw
+    }
 }
 
 if ($_sha_ok -and (Test-Path -LiteralPath "${_sha_path}")) {

--- a/scripts/windowsish-17.ps1
+++ b/scripts/windowsish-17.ps1
@@ -56,6 +56,45 @@ Invoke-WebRequest -Uri "${_dl_url}" -OutFile "${_dl_path}"
 
 Write-Host "::endgroup::"
 
+Write-Host "::group::Verifying checksum"
+
+$_sha_url = "${_base_url}/jq-$Env:JQ_VERSION/sha256sum.txt"
+$_sha_path = "$Env:RUNNER_TEMP\jq-$Env:JQ_VERSION.sha256sum.txt"
+
+$_sha_ok = $true
+try {
+    Invoke-WebRequest -Uri "${_sha_url}" -OutFile "${_sha_path}"
+} catch {
+    $_sha_ok = $false
+}
+
+if ($_sha_ok -and (Test-Path -LiteralPath "${_sha_path}")) {
+    $_expected = $null
+    foreach ($_line in Get-Content -LiteralPath "${_sha_path}") {
+        $_parts = $_line -split '\s+'
+        if ($_parts.Length -ge 2 -and $_parts[1] -eq "${_bin_name}") {
+            $_expected = $_parts[0]
+            break
+        }
+    }
+    if (-not $_expected) {
+        Write-Host "Could not find checksum for \"${_bin_name}\" in ${_sha_url}"
+        exit 1
+    }
+    $_actual = (Get-FileHash -Algorithm SHA256 -LiteralPath "${_dl_path}").Hash.ToLower()
+    if ($_expected.ToLower() -ne $_actual) {
+        Write-Host "Checksum verification failed for \"${_bin_name}\""
+        Write-Host "Expected: $_expected"
+        Write-Host "Actual:   $_actual"
+        exit 1
+    }
+    Write-Host "Checksum verified for \"${_bin_name}\""
+} else {
+    Write-Host "WARNING: No sha256sum.txt found at ${_sha_url}; skipping checksum verification."
+}
+
+Write-Host "::endgroup::"
+
 # install into tool cache
 
 Write-Host "::group::Copying to tool cache"

--- a/scripts/windowsish-17.ps1
+++ b/scripts/windowsish-17.ps1
@@ -3,6 +3,11 @@ Set-StrictMode -Version Latest
 
 Write-Host "::group::Prep"
 
+if (-not ($Env:JQ_VERSION -match '^[0-9]+\.[0-9]+(\.[0-9]+)*$')) {
+    Write-Host "Invalid JQ_VERSION: '$Env:JQ_VERSION'. Expected a version string like '1.7.1'."
+    exit 1
+}
+
 $_base_url = "https://github.com/jqlang/jq/releases/download"
 
 $_arch_env = ($Env:RUNNER_ARCH).ToLower()
@@ -78,17 +83,17 @@ if ($_sha_ok -and (Test-Path -LiteralPath "${_sha_path}")) {
         }
     }
     if (-not $_expected) {
-        Write-Host "Could not find checksum for \"${_bin_name}\" in ${_sha_url}"
+        Write-Host "Could not find checksum for '${_bin_name}' in ${_sha_url}"
         exit 1
     }
     $_actual = (Get-FileHash -Algorithm SHA256 -LiteralPath "${_dl_path}").Hash.ToLower()
     if ($_expected.ToLower() -ne $_actual) {
-        Write-Host "Checksum verification failed for \"${_bin_name}\""
+        Write-Host "Checksum verification failed for '${_bin_name}'"
         Write-Host "Expected: $_expected"
         Write-Host "Actual:   $_actual"
         exit 1
     }
-    Write-Host "Checksum verified for \"${_bin_name}\""
+    Write-Host "Checksum verified for '${_bin_name}'"
 } else {
     Write-Host "WARNING: No sha256sum.txt found at ${_sha_url}; skipping checksum verification."
 }

--- a/scripts/windowsish.ps1
+++ b/scripts/windowsish.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version Latest
 Write-Host "::group::Prep"
 
 if (-not ($Env:JQ_VERSION -match '^[0-9]+\.[0-9]+(\.[0-9]+)*$')) {
-    Write-Host "Invalid JQ_VERSION: \"$Env:JQ_VERSION\". Expected a version string like \"1.6\"."
+    Write-Host "Invalid JQ_VERSION: '$Env:JQ_VERSION'. Expected a version string like '1.6'."
     exit 1
 }
 

--- a/scripts/windowsish.ps1
+++ b/scripts/windowsish.ps1
@@ -3,6 +3,11 @@ Set-StrictMode -Version Latest
 
 Write-Host "::group::Prep"
 
+if (-not ($Env:JQ_VERSION -match '^[0-9]+\.[0-9]+(\.[0-9]+)*$')) {
+    Write-Host "Invalid JQ_VERSION: \"$Env:JQ_VERSION\". Expected a version string like \"1.6\"."
+    exit 1
+}
+
 # validate input and prepare some vars
 
 switch ($Env:RUNNER_ARCH)


### PR DESCRIPTION
## Summary

Security hardening of the jq install path, plus CI fixes for two GitHub Actions deprecations. Addresses gaps that could allow a corrupted or tampered binary to be installed into the tool cache and `GITHUB_PATH`.

### Node runtime → node24

Node 20 is being **deprecated on GitHub Actions runners** (announced 2025-09-19): https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The only node20 in this repo was the `test-container` job's container image (`node:20`). JS actions such as `actions/checkout` execute on the container's Node runtime, so the container must move to a supported Node. Bumped to `node:24`.

| Component | Before | After |
|---|---|---|
| `actions/checkout@v6` (in `tests.yaml`) | node24 | node24 (already good — checkout v5+ runs on node24) |
| `test-container` job image | `node:20` | `node:24` |

`action.yaml` itself is `using: composite` with only `sh`/`powershell` steps, so there is no JS runtime beneath the action itself — the bump only affects the test container.

### macOS runners → dropped `macos-13`

The macOS 13 runner image is **closing down** (announced 2025-09-19): https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

With the image decommissioned, `macos-13` jobs sit perpetually queued and can no longer be allocated. Removed `macos-13` from the `tests.yaml` matrix; `macos-14`, `macos-15`, and `macos-26` remain, so macOS continues to be covered (including the checksum-verification path).

### Security changes

1. **Download integrity verification (supply-chain).** `unixish-17.sh` and `windowsish-17.ps1` now fetch each release's `sha256sum.txt`, compute the binary's SHA256, and **fail closed on mismatch**. When no checksum file is published (e.g. jq 1.7.0, or the legacy `stedolan/jq` 1.5/1.6 releases which publish none), they warn and proceed.
2. **Portable SHA256 on macOS.** `sha256sum` is a GNU/coreutils binary absent on stock macOS (it broke `macos-13`/`macos-14` with `sha256sum: command not found`). `unixish-17.sh` now uses a `_compute_sha256` helper that prefers `sha256sum` (Linux) and falls back to `shasum -a 256` (ships with macOS via Perl), then `openssl`.
3. **`curl` hardened** in `unixish.sh` / `unixish-17.sh` with `--fail` and `--retry`. Previously `curl -L` returned 0 on a 404/5xx and wrote the HTML error body to disk, which was then `chmod +x`'d and installed.
4. **`JQ_VERSION` input validated** (digits and dots only) across all four install scripts, rejecting malformed / path-traversal values before they reach download URLs.

## Verification

CI is green on the fork's `main` (the test workflow runs `uses: ./`, so it exercises these changes directly): https://github.com/mountaintopsolutions/install-jq-action/actions — 78/78 jobs passing (Linux, macOS 14/15/26, Windows 2022/2025, and the `node:24` container job), including all `force: true` jobs that download + checksum-verify + install jq.

Additional checks performed locally:
- `sh -n` on both `.sh` scripts; PowerShell parser (`[Parser]::ParseFile`) on both `.ps1` scripts — all clean.
- End-to-end run of `unixish-17.sh` for jq 1.7.1 on Linux: download → **checksum verified** → installed → `jq --version` reports `jq-1.7.1`.
- Tampered binary → correctly **rejected** (checksum mismatch).
- `_compute_sha256` fallback verified: with `sha256sum` absent (macOS-like PATH), `shasum -a 256` produces the correct digest.
- `JQ_VERSION='1.7.1; rm -rf /'` and `'../../etc/passwd'` → **rejected** by input validation.
- Missing `sha256sum.txt` → warns and proceeds.
- `curl -fsSL` against a 404 binary → exit 22 (old `curl -L` exited 0 and saved HTML).
- Checksum lookup confirmed to not false-match sibling asset names (`jq-linux-amd64` vs `jq-linux64` vs `jq-windows-amd64.exe`).

## Notes

- `stedolan/jq` 1.5/1.6 publish no checksums, so the legacy install path (`unixish.sh` / `windowsish.ps1`) cannot be integrity-verified; users are nudged toward 1.7+ where checksums exist.
- No behavior change for the happy path; only adds validation and verification.
