### PR TITLE
feat: add jq 1.8.1 and 1.8.2, default to 1.8.2

### DIFF
--- a/.github/workflows/example-linux.yaml
+++ b/.github/workflows/example-linux.yaml
@@ -24,7 +24,7 @@ on:
         type: string
         required: false
         description: 'Version of jq to install'
-        default: '1.7.1'
+        default: '1.8.2'
       force:
         type: boolean
         required: false

--- a/.github/workflows/example-macos.yaml
+++ b/.github/workflows/example-macos.yaml
@@ -24,7 +24,7 @@ on:
         type: string
         required: false
         description: 'Version of jq to install'
-        default: '1.7.1'
+        default: '1.8.2'
       force:
         type: boolean
         required: false

--- a/.github/workflows/example-windows.yaml
+++ b/.github/workflows/example-windows.yaml
@@ -24,7 +24,7 @@ on:
         type: string
         required: false
         description: 'Version of jq to install'
-        default: '1.7.1'
+        default: '1.8.2'
       force:
         type: boolean
         required: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,8 @@ jobs:
           - '1.7'
           - '1.7.1'
           - '1.8.0'
+          - '1.8.1'
+          - '1.8.2'
         include:
           - image: "ubuntu-22.04"
             version: '1.6'
@@ -246,6 +248,8 @@ jobs:
           - '1.7'
           - '1.7.1'
           - '1.8.0'
+          - '1.8.1'
+          - '1.8.2'
     name: "Test Action (Container) - (img: ${{ matrix.image }}; version: ${{ matrix.version }}; force: ${{ matrix.force }})"
     runs-on: '${{ matrix.image }}'
     container:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Multiplatform [jq](https://github.com/jqlang/jq) installer action
 This action is tested against the following versions of jq:
 
 **Modern releases (jqlang/jq — 1.7+)**
+- [1.8.2](https://github.com/jqlang/jq/releases/tag/jq-1.8.2)
+- [1.8.1](https://github.com/jqlang/jq/releases/tag/jq-1.8.1)
 - [1.8.0](https://github.com/jqlang/jq/releases/tag/jq-1.8.0)
 - [1.7.1](https://github.com/jqlang/jq/releases/tag/jq-1.7.1)
 - [1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7)
@@ -35,7 +37,7 @@ This action is tested against the following versions of jq:
   version:
     required: false
     description: "Version of jq to install"
-    default: "1.7.1"
+    default: "1.8.2"
 ```
 
 Must be a dot-separated numeric version string (e.g. `1.7.1`, `1.8.0`).

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
   version:
     required: false
     description: "Version of jq to install."
-    default: "1.7.1"
+    default: "1.8.2"
   force:
     required: false
     description: "If 'true', does not check for existing jq installation before continuing."


### PR DESCRIPTION
- Add 1.8.1 and 1.8.2 to the test-linux and test-container matrices.
- Bump default version in action.yaml from 1.7.1 to 1.8.2.
- Update README tested-version list and default snippet.
- Update example workflow dispatch defaults to 1.8.2.